### PR TITLE
default JC SDK version changed from 3.0.4 to 2.2.2

### DIFF
--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -52,7 +52,7 @@ final def JC304 = libsSdk + '/jc304_kit'
 final def JC305 = libsSdk + '/jc305u1_kit'
 
 // Which JavaCard SDK to use - select
-final def JC_SELECTED = JC304
+final def JC_SELECTED = JC222
 
 javacard {
 


### PR DESCRIPTION
The majority of smartcards do support JC 2.2.2, but only few JC 3.0.4. Wider compatibility is thus achieved (example applet use no specific class/algorithm not available in JC2.2.2)