### PR TITLE
Fixed Unable to Load APDU error

### DIFF
--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -1,5 +1,6 @@
 group 'test-applet'
 version '1.0-SNAPSHOT'
+apply plugin: 'com.klinec.gradle.javacard'
 
 // Buildscript configuration for the javacard-gradle plugin.
 // Do not modify this particular block. Dependencies for the project are lower.
@@ -13,7 +14,6 @@ buildscript {
     }
 }
 
-apply plugin: 'com.klinec.gradle.javacard'
 sourceCompatibility = 1.8
 
 // Common settings, definitions


### PR DESCRIPTION
The error stated to make sure that plugin is loaded before classpath. After doing so the tests ran successfully