### PR TITLE
Ignore application class when building cap file

### DIFF
--- a/applet/build.gradle
+++ b/applet/build.gradle
@@ -129,7 +129,9 @@ javacard {
             packageName 'applet'
             version '0.1'
             aid '01:ff:ff:04:05:06:07:08:09'
-            output 'applet.cap'
+            output 'applet_main_applet.cap'
+
+            sources 'src/main/java/applet'
 
             // JC310b43 supports compilation targeting for lower API versions.
             // Here you can specify path to the SDK you want to use.
@@ -144,6 +146,35 @@ javacard {
             applet {
                 className 'applet.MainApplet'
                 aid '01:ff:ff:04:05:06:07:08:09:01:02'
+            }
+
+            //noinspection GroovyAssignabilityCheck
+            // dependencies {
+            //     remote 'com.klinec:globalplatform:2.1.1'
+            // }
+        }
+
+        cap {
+            packageName 'applet'
+            version '0.1'
+            aid '01:ff:ff:04:05:06:07:08:0A'
+            output 'applet_hello_world.cap'
+
+            sources 'src/main/java/applet'
+
+            // JC310b43 supports compilation targeting for lower API versions.
+            // Here you can specify path to the SDK you want to use.
+            // Only JC304 and higher are supported for targeting.
+            // If JC310b43 is not used, targetsdk cannot be set.
+            targetsdk JC304
+
+            // Override java bytecode version if needed.
+            // javaversion '1.7'
+
+            //noinspection GroovyAssignabilityCheck
+            applet {
+                className 'applet.HelloWorldApplet'
+                aid '01:ff:ff:04:05:06:07:08:0A:01:02'
             }
 
             //noinspection GroovyAssignabilityCheck


### PR DESCRIPTION
Currently, the `Run.java` file is picked up by the gradle build when building the cap file, but this doesn't work (or make sense) because this class is for running the simulation only. This fix forces it to only look in the applet folder for code when building the cap file, and it also changes the build so that both applet cap files are built separately instead of just building only one of the two applets.

Fixes https://github.com/ph4r05/javacard-gradle-template/issues/15